### PR TITLE
"Fixes" unify script not working completely on world load.

### DIFF
--- a/kubejs/server_scripts/unify/reloadOnLoad.js
+++ b/kubejs/server_scripts/unify/reloadOnLoad.js
@@ -1,0 +1,7 @@
+// priority: 1000
+let reloaded = false;
+ServerEvents.loaded((e) => {
+  if (!reloaded) {
+    e.server.runCommandSilent('reload');
+  }
+});


### PR DESCRIPTION
I have absolutely 0 idea why this is required, but for some reason KubeJS scripts error out on first world load, and they work just fine after doing a "/reload" after loading in, so this file just does that command on world load.

I will probably go through the script later on to implement a proper fix, but this works for now.