### PR TITLE
Update Ars_Nouveau.snbt

### DIFF
--- a/config/ftbquests/quests/chapters/Ars_Nouveau.snbt
+++ b/config/ftbquests/quests/chapters/Ars_Nouveau.snbt
@@ -581,21 +581,6 @@
 			}]
 			tasks: [
 				{
-					id: "54E51D5E5BA5D1D6"
-					item: { count: 1, id: "ars_nouveau:glyph_projectile" }
-					type: "item"
-				}
-				{
-					id: "0ECF2BCD82499290"
-					item: { count: 1, id: "ars_nouveau:glyph_self" }
-					type: "item"
-				}
-				{
-					id: "38FED4F9A729E1B5"
-					item: { count: 1, id: "ars_nouveau:glyph_touch" }
-					type: "item"
-				}
-				{
 					id: "0A2377ABF1716224"
 					item: { count: 1, id: "ars_nouveau:glyph_underfoot" }
 					type: "item"
@@ -618,11 +603,6 @@
 				{
 					id: "74A49A281AF277FF"
 					item: { count: 1, id: "ars_nouveau:glyph_bounce" }
-					type: "item"
-				}
-				{
-					id: "34BB77DA0E307BA1"
-					item: { count: 1, id: "ars_nouveau:glyph_break" }
 					type: "item"
 				}
 				{
@@ -668,11 +648,6 @@
 				{
 					id: "5FB352A2B3D9C14E"
 					item: { count: 1, id: "ars_nouveau:glyph_freeze" }
-					type: "item"
-				}
-				{
-					id: "43DACB7B925F84D4"
-					item: { count: 1, id: "ars_nouveau:glyph_harm" }
 					type: "item"
 				}
 				{


### PR DESCRIPTION
Remove requirement to craft auto-granted starter glyphs -- otherwise players have to craft glyphs that no-one can use, only to trash them afterwards