### PR TITLE
allow lower tier quests to complete before higher ones

### DIFF
--- a/config/ftbquests/quests/chapters/Mekanism Ore Processing.snbt
+++ b/config/ftbquests/quests/chapters/Mekanism Ore Processing.snbt
@@ -16,6 +16,7 @@
 				"5E34B88FE17081A6"
 			]
 			id: "4EB96A7E9F529D80"
+			min_required_dependencies: 1
 			rewards: [{
 				exclude_from_claim_all: true
 				id: "5A39A685CFF1DCD3"
@@ -37,6 +38,7 @@
 				"1DF9676C04AFADC2"
 			]
 			id: "5E34B88FE17081A6"
+			min_required_dependencies: 1
 			rewards: [{
 				exclude_from_claim_all: true
 				id: "774C06D9AA7C5A67"
@@ -78,6 +80,7 @@
 			]
 			dependency_requirement: "one_completed"
 			id: "56AD980E166F9D02"
+			min_required_dependencies: 2
 			rewards: [{
 				exclude_from_claim_all: true
 				id: "5F2BFB0710797614"
@@ -101,6 +104,7 @@
 				"060D9F59EB26C7BD"
 			]
 			id: "126734923F4BCC42"
+			min_required_dependencies: 2
 			rewards: [{
 				exclude_from_claim_all: true
 				id: "03B79E8E7DC8A254"
@@ -161,6 +165,7 @@
 				"3F8B9421E85C047D"
 			]
 			id: "14CE0DA0E5358A10"
+			min_required_dependencies: 1
 			rewards: [{
 				exclude_from_claim_all: true
 				id: "7CAD99F0E595C54E"


### PR DESCRIPTION
My bad. I do like to break peeps out of linear thinking, but after discussing it with a player (only hours after the update hit! ^^) I think it best for their tiers to be completable independently, even though each higher one subsumes the previous.