### PR TITLE
Un-needed lines in server-setup-config.yaml result in server running with JFR enabled

### DIFF
--- a/server_files/server-setup-config.yaml
+++ b/server_files/server-setup-config.yaml
@@ -61,5 +61,3 @@ launch:
   startCommand: 
     - "@libraries/net/neoforged/neoforge/{{@loaderversion@}}/{{@os@}}_args.txt"
     - "nogui"
-    - "-jar"
-    - "libraries/net/neoforged/neoforge/{{@loaderversion@}}/neoforge-{{@loaderversion@}}-server.jar"


### PR DESCRIPTION
Draft until I test on Windows too.