### PR TITLE
Fix JFR being started automatically

### DIFF
--- a/server_files/server-setup-config.yaml
+++ b/server_files/server-setup-config.yaml
@@ -61,5 +61,3 @@ launch:
   startCommand: 
     - "@libraries/net/neoforged/neoforge/{{@loaderversion@}}/{{@os@}}_args.txt"
     - "nogui"
-    - "-jar"
-    - "libraries/net/neoforged/neoforge/{{@loaderversion@}}/neoforge-{{@loaderversion@}}-server.jar"


### PR DESCRIPTION
-jar cannot be added after the os arguments. the launch class and libraries are added via the os_args.txt files