### PR TITLE
Update Recipes.js

### DIFF
--- a/kubejs/server_scripts/Mods/JustDireThings/Recipes.js
+++ b/kubejs/server_scripts/Mods/JustDireThings/Recipes.js
@@ -156,4 +156,8 @@ ServerEvents.recipes((event) => {
       .itemOut(`4x justdirethings:${ore}`)
       .id(`craftoria:justdirethings/macerator/${ore}`);
   });
+
+  event.smithing('justdirethings:celestigem_paxel', 'justdirethings:celestigem_axe', 'justdirethings:celestigem_shovel')
+    .template('justdirethings:celestigem_pickaxe');
+  
 });


### PR DESCRIPTION
Apparently adding a kubejs smithing recipe for the Celestigem Paxel makes it show up in EMI...