### PR TITLE
Mention compressed blocks blacklist in MI Replicator quest

### DIFF
--- a/config/ftbquests/quests/lang/en_us.snbt
+++ b/config/ftbquests/quests/lang/en_us.snbt
@@ -564,7 +564,7 @@
 		""
 		"Use your &dUniversally Useable Matter&r to &6duplicate&r anything you desire; with one &dlimits&r. "
 		""
-		"Remember, &dmatter&r cannot be created from &bnothing&r, so trying to &6duplicate&r a &bbackpack&r full of &bitems&r will be a fruitless endeavor. "
+		"Remember, &dmatter&r cannot be created from &bnothing&r, so trying to &6duplicate&r highly &bcompressed&r blocks or a &bbackpack&r full of &bitems&r will be a fruitless endeavor. "
 		""
 		"Other than that, you are free to do as you please. Use this new found &6power&r wisely!"
 	]


### PR DESCRIPTION
Compressed blocks are blacklisted from duplication through the MI Replicator, but that is not mentioned in the quest. This can cause some players to think they can replicate hundreds of millions of resources using a single bucket of UU Matter, when in fact trying to do so "will be a fruitless endeavor."