### PR TITLE
The Plankening, Part 2 (2Planks2Furious)

### DIFF
--- a/kubejs/server_scripts/Mods/ModernIndustrialization/Recipe_Functions.js
+++ b/kubejs/server_scripts/Mods/ModernIndustrialization/Recipe_Functions.js
@@ -32,8 +32,8 @@ let miProcessItemInputs = (itemInputs, recipe, maxInputs) => {
           if (Array.isArray(itemInput) && (itemInput.length === 2 || itemInput.length === 3)) {
             let input = {};
 
-            if (itemInput[0].includes("c:")) {
-              input.tag = itemInput[0];
+            if (itemInput[0].includes("c:") || itemInput[0].includes("#")) {
+              input.tag = itemInput[0].replace("#", "");
             } else {
               input.item = itemInput[0];
             }
@@ -55,8 +55,8 @@ let miProcessItemInputs = (itemInputs, recipe, maxInputs) => {
         if (itemInputs.length === 2 || itemInputs.length === 3) {
           let input = {};
 
-          if (itemInputs[0].includes("c:")) {
-            input.tag = itemInputs[0];
+          if (itemInputs[0].includes("c:") || itemInputs[0].includes("#")) {
+            input.tag = itemInputs[0].replace("#", "");
           } else {
             input.item = itemInputs[0];
           }

--- a/kubejs/server_scripts/Mods/ModernIndustrialization/Recipes.js
+++ b/kubejs/server_scripts/Mods/ModernIndustrialization/Recipes.js
@@ -35,4 +35,78 @@ ServerEvents.recipes((e) => {
   ['gold', 'iron'].forEach((material) => {
     e.replaceInput({ mod: 'modern_industrialization' }, `#c:gears/${material}`, `modern_industrialization:${material}_gear`);
   });
+
+  // cutting machine recipes to give other modded logs parity with vanilla:
+  const modded_logs = [
+    'biomeswevegone:aspen',
+    'biomeswevegone:baobab',
+    'biomeswevegone:blue_enchanted',
+    'biomeswevegone:cika',
+    'biomeswevegone:cypress',
+    'biomeswevegone:ebony',
+    'biomeswevegone:fir',
+    'biomeswevegone:florus',
+    'biomeswevegone:green_enchanted',
+    'biomeswevegone:holly',
+    'biomeswevegone:ironwood',
+    'biomeswevegone:jacaranda',
+    'biomeswevegone:mahogany',
+    'biomeswevegone:maple',
+    'biomeswevegone:palm',
+    'biomeswevegone:pine',
+    'biomeswevegone:rainbow_eucalyptus',
+    'biomeswevegone:redwood',
+    'biomeswevegone:sakura',
+    'biomeswevegone:skyris',
+    'biomeswevegone:spirit',
+    'biomeswevegone:white_mangrove',
+    'biomeswevegone:willow',
+    'biomeswevegone:witch_hazel',
+    'biomeswevegone:zelkova',
+	  'eternal_starlight:lunar',
+	  'eternal_starlight:northland',
+	  'eternal_starlight:starlight_mangrove',
+	  'eternal_starlight:scarlet',
+	  'eternal_starlight:torreya',
+  ];
+  
+  // common factors for all recipes:
+  let w_lube = ['modern_industrialization:lubricant', 1];
+  let w_eu = 2;
+  let w_t = 100;
+  
+  modded_logs.forEach((wood) => {
+	  miCuttingMachine(e, w_lube, [`#${wood}_logs`, 1], [`${wood}_planks`, 6], w_eu, w_t);
+	  if (`${wood}` != 'biomeswevegone:florus') {
+	    miCuttingMachine(e, w_lube, [`${wood}_log`, 1], [(`${wood}_log`).replace(':', ':stripped_'), 1], w_eu, w_t);
+	  } else {
+	    miCuttingMachine(e, w_lube, [`${wood}_stem`, 1], [(`${wood}_stem`).replace(':', ':stripped_'), 1], w_eu, w_t);
+	  };
+	  miCuttingMachine(e, w_lube, [`${wood}_wood`, 1], [(`${wood}_wood`).replace(':', ':stripped_'), 1], w_eu, w_t);
+  });
+  
+  // ars nouveau logs (plus addons) all output the same planks:
+  miCuttingMachine(e, w_lube, ['c:logs/archwood', 1], ['ars_nouveau:archwood_planks', 6], w_eu, w_t);
+
+  const arch_logs = [
+    'green',
+    'blue',
+	  'red',
+    'purple'
+  ];
+
+  // ars nouveau stripped logs/wood:
+  arch_logs.forEach((colour) => {
+    miCuttingMachine(e, w_lube, [`ars_nouveau:${colour}_archwood_log`, 1], [`ars_nouveau:stripped_${colour}_archwood_log`, 1], w_eu, w_t);
+    miCuttingMachine(e, w_lube, [`ars_nouveau:${colour}_archwood_wood`, 1], [`ars_nouveau:stripped_${colour}_archwood_wood`, 1], w_eu, w_t);
+  });
+  
+  // ars elemental is different from its parent mod for ... reasons:
+  miCuttingMachine(e, w_lube, ['ars_elemental:yellow_archwood_log', 1], ['ars_elemental:stripped_yellow_archwood_log', 1], w_eu, w_t);
+  miCuttingMachine(e, w_lube, ['ars_elemental:yellow_archwood', 1], ['ars_elemental:stripped_yellow_archwood', 1], w_eu, w_t);
+  
+  // integrated dynamics handled separately due to inconsistent naming:
+  miCuttingMachine(e, w_lube, ['#integrateddynamics:menril_logs', 1], ['integrateddynamics:menril_planks', 6], w_eu, w_t);
+  miCuttingMachine(e, w_lube, ['integrateddynamics:menril_log', 1], ['integrateddynamics:menril_log_stripped', 1], w_eu, w_t);
+  miCuttingMachine(e, w_lube, ['integrateddynamics:menril_wood', 1], ['integrateddynamics:menril_wood_stripped', 1], w_eu, w_t);
 });


### PR DESCRIPTION
Add MI cutting machine recipes for planks, stripped logs and stripped wood so the output of modded logs have parity with vanilla log types.

This PR also makes small adjustments to one of @WhitePhant0m's MI helper functions to enable the plank recipes without adding a heap of extra tags, so keen to get his take on whether the changes are likely to break anything (tested locally without issue).