### PR TITLE
Fix incorrect value in Mekanism tools config

### DIFF
--- a/config/Mekanism/tools-materials-startup.toml
+++ b/config/Mekanism/tools-materials-startup.toml
@@ -605,7 +605,7 @@
 		#Attack speed of Refined Obsidian pickaxes.
 		refined_obsidianPickaxeAtkSpeed = -2.799999952316284
 		#Attack damage modifier of Refined Obsidian hoes.
-		refined_obsidianHoeDamage = -8.0
+		refined_obsidianHoeDamage = -5.0
 		#Attack speed of Refined Obsidian hoes.
 		refined_obsidianHoeAtkSpeed = 5.0
 		#Efficiency of Refined Obsidian tools.


### PR DESCRIPTION
The default value of `refined_obsidianHoeDamage` in Mekanism Tools' `tools-materials-startup.toml` config file is incompatible with the value of `refined_obsidianAttackDamage` in such a way that the automatic fixer which runs when invalid config values are detected tries to run repeatedly to no effect while filling up the log files.

I've changed the `refined_obsidianHoeDamage` value to `-5.0`, which is the lowest supported value given the value of `refined_obsidianAttackDamage`. This should fix the repeating error.

(The default value of `refined_obsidianAttackDamage` is `8.0`, but the current value was reduced to `5.0` during modpack balancing, causing the error.)