### PR TITLE
Be more precise for Plasma Turbine EU generation rate

### DIFF
--- a/config/ftbquests/quests/lang/en_us.snbt
+++ b/config/ftbquests/quests/lang/en_us.snbt
@@ -1637,7 +1637,7 @@
 	quest.33D0760B5FEF7C46.quest_desc: [
 		"  &oThis&r is the ultimate generator."
 		""
-		"  The &bPlasma Turbine&r uses &bHelium Plasma&r to produce energy, &6up to 1,049,000 EU/t&r. This is about 100,000 EU per millibucket of &bHelium Plasma&r, and a &6consumption rate of about 11 mb/t&r."
+		"  The &bPlasma Turbine&r uses &bHelium Plasma&r to produce energy, &6up to 1,048,576 EU/t&r. This is about 100,000 EU per millibucket of &bHelium Plasma&r, and a &6consumption rate of about 11 mb/t&r."
 		""
 		"  As long as you know how to care for your factory, you will &onever&r need to worry about power ever again."
 	]


### PR DESCRIPTION
According to the source code of Modern Industrialization, which the Plasma Turbine is from, the turbine's exact EU generation rate is 1,048,576 EU/t, not 1,049,000 EU/t. The 1,049,000 EU/t value comes from the tooltip which shows the generation rate rounded to the thousands place as 1.049M EU/t.

The relevant code can be found here (note `1 << 20 == 1048576`):
https://github.com/AztechMC/Modern-Industrialization/blob/5d9c1b69f3d6d683554f2003f6c688b89909e676/src/main/java/aztech/modern_industrialization/machines/init/MultiblockMachines.java#L542-L547