### PR TITLE
Lower netherrack output through MI gold drill again by making it probabilistic

### DIFF
--- a/kubejs/server_scripts/Mods/ModernIndustrialization/Quarry.js
+++ b/kubejs/server_scripts/Mods/ModernIndustrialization/Quarry.js
@@ -87,7 +87,7 @@ ServerEvents.recipes(event => {
 
   // Gold Drill
   MIQuarry(["modern_industrialization:gold_drill", 1, 0.1], [
-    ["minecraft:netherrack", 32, 1],
+    ["minecraft:netherrack", 32, 0.5],
     ["minecraft:blackstone", 16, 0.25],
     ["minecraft:basalt", 16, 0.25],
     ["minecraft:soul_soil", 20, 0.1],


### PR DESCRIPTION
This brings the netherrack output when using MI Gold Drills in line with base MI, allowing setups which void netherrack from gold drills by not putting in any hatches for it to work properly in Craftoria.

See also https://github.com/AztechMC/Modern-Industrialization/commit/c09303598d27e96a785ff7f29da1721ad14b09c8, which contains the latest (as of 2.2.30) cobblestone and netherrack output amounts and probabilities in base MI.