### PR TITLE
Fix incorrect tag entry (`wardern` → `warden`)

### DIFF
--- a/kubejs/server_scripts/tags.js
+++ b/kubejs/server_scripts/tags.js
@@ -118,5 +118,5 @@ ServerEvents.tags('fluid', (e) => {
 
 ServerEvents.tags('entity_type', (e) => {
   e.add('ftbchunks:entity_interact_whitelist', ['minecraft:villager']);
-  e.add('mob_grinding_utils:entity_type/no_swab', ['artifacts:mimic', 'minecraft:wardern']);
+  e.add('mob_grinding_utils:entity_type/no_swab', ['artifacts:mimic', 'minecraft:warden']);
 });


### PR DESCRIPTION
`minecraft:wardern` does not exist; but the intent there was to disable the creation of Warden spawn eggs through Mob Grinding Utils. The entry is fixed to the correct value of `minecraft:warden`.

The incorrect entry was added in b79e6f37c8ba84aa95d1279d455953aa5f620b8d.