### PR TITLE
Added "Stone Pickaxe Mineable" tag and loot table to Replicator MK I.

### DIFF
--- a/kubejs/data/minecraft/tags/block/mineable/pickaxe.json
+++ b/kubejs/data/minecraft/tags/block/mineable/pickaxe.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "modern_industrialization:replicator_1"
+  ]
+}

--- a/kubejs/data/minecraft/tags/block/needs_stone_tool.json
+++ b/kubejs/data/minecraft/tags/block/needs_stone_tool.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "modern_industrialization:replicator_1"
+  ]
+}

--- a/kubejs/data/modern_industrialization/loot_table/blocks/replicator_1.json
+++ b/kubejs/data/modern_industrialization/loot_table/blocks/replicator_1.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "modern_industrialization:replicator_1"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "modern_industrialization:blocks/replicator_1"
+}


### PR DESCRIPTION
This PR allows Replicator MK I to be broken with an effective tool and drop its item as expected.
This change ensures consistency with other MI machines.