### PR TITLE
Except more Knives from auto disabling

### DIFF
--- a/kubejs/server_scripts/unify/Knife.js
+++ b/kubejs/server_scripts/unify/Knife.js
@@ -1,6 +1,6 @@
 ServerEvents.recipes((e) => {
   Ingredient.of('#c:tools/knife').stacks.forEach((item) => {
-    if (item.mod === 'farmersdelight' || item.mod === 'moredelight' || item.id === 'aquaculture:neptunium_fillet_knife') return;
+    if (item.mod === 'farmersdelight' || item.mod === 'moredelight' || item.mod === 'arsdelight' || item.mod === 'twilightdelight' || item.mod === 'ends_delight' || item.id === 'aquaculture:neptunium_fillet_knife') return;
     globalItemRemovals.push(item.id);
   });
 
@@ -16,7 +16,7 @@ ServerEvents.tags('item', (e) => {
 
   let hiddenKnives = [];
   Ingredient.of('#c:tools/knife').stacks.forEach((item) => {
-    if (item.mod === 'farmersdelight' || item.mod === 'moredelight' || item.id === 'aquaculture:neptunium_fillet_knife') return;
+    if (item.mod === 'farmersdelight' || item.mod === 'moredelight' || item.mod === 'arsdelight' || item.mod === 'twilightdelight' || item.mod === 'ends_delight' || item.id === 'aquaculture:neptunium_fillet_knife') return;
     hiddenKnives.push(item.id);
   });
   e.add('almostunified:hide', hiddenKnives);


### PR DESCRIPTION
Lots of knives are wrongly hidden when they really should not be; I've changed that to exclude (hopefully all of) the FD addons with knives from the disabling and hiding script.