### PR TITLE
fix: prevent the usage of gates in compact machines

### DIFF
--- a/kubejs/server_scripts/Mods/GatewaysToEternity/Events.js
+++ b/kubejs/server_scripts/Mods/GatewaysToEternity/Events.js
@@ -1,0 +1,6 @@
+BlockEvents.rightClicked("compactmachines:solid_wall", (e) => {
+  if (e.item.id == "gateways:gate_pearl") {
+    e.player.tell("Gates cannot be opened in this dimension.");
+    e.cancel();
+  }
+});

--- a/kubejs/server_scripts/Mods/GatewaysToEternity/Events.js
+++ b/kubejs/server_scripts/Mods/GatewaysToEternity/Events.js
@@ -1,5 +1,6 @@
-BlockEvents.rightClicked("compactmachines:solid_wall", (e) => {
-  if (e.item.id == "gateways:gate_pearl") {
+BlockEvents.rightClicked((e) => {
+  if (e.item.id != "gateways:gate_pearl") return;
+  if (e.level.dimension == "compactmachines:compact_world") {
     e.player.tell("Gates cannot be opened in this dimension.");
     e.cancel();
   }


### PR DESCRIPTION
Gateways of Eternity gates and waves are completed/get cleared inside compact machines upon entry and exit.
Discord bug report with video(IMPORTANT): https://discord.com/channels/570630340075454474/1353450387117572207
