### PR TITLE
Add Curios support for Mekanism Jetpack; adjust recipe balance.

### DIFF
--- a/config/Mekanism/gear.toml
+++ b/config/Mekanism/gear.toml
@@ -117,11 +117,11 @@
 	#Jetpack tank capacity in mB.
 	# Default: 24000
 	# Range: 1 ~ 9223372036854775807
-	capacity = 24000
+	capacity = 72000
 	#Rate in mB/t at which a Jetpack's tank can accept hydrogen.
 	# Default: 16
 	# Range: 1 ~ 9223372036854775807
-	fillRate = 16
+	fillRate = 32
 
 #Settings for configuring Network Readers
 [network_reader]

--- a/config/mekanismcovers.json
+++ b/config/mekanismcovers.json
@@ -1,3 +1,0 @@
-{
-  "disableAdvancedCoverRendering": true
-}

--- a/kubejs/server_scripts/Mods/Mekanism/Recipes.js
+++ b/kubejs/server_scripts/Mods/Mekanism/Recipes.js
@@ -164,6 +164,20 @@ ServerEvents.recipes((e) => {
     D: 'mekanism_extras:cosmic_control_circuit',
   }).id('mekaweapons:bow_riser');
 
+  e.shaped('mekanism:jetpack', ['ADA','BCB',' B '], {
+    A: 'modern_industrialization:steel_ingot',
+    B: 'modern_industrialization:tin_double_ingot',
+    C: 'mekanism:ultimate_chemical_tank',
+    D: 'mekanism:ultimate_control_circuit',
+  }).id('mekanism:jetpack');
+
+  e.shaped('mekanism:jetpack_armored', ['A A','BCB',' D '], {
+    A: 'mekanism:dust_diamond',
+    B: 'modern_industrialization:bronze_double_ingot',
+    C: 'modern_industrialization:steel_block',
+    D: 'mekanism:jetpack',
+  }).id('mekanism:jetpack_armored');
+
   e.replaceInput({ id: 'mekanism:mekasuit_helmet' }, 'mekanism:ultimate_control_circuit', 'mekanism_extras:supreme_control_circuit');
   e.replaceInput({ id: 'mekanism:mekasuit_bodyarmor' }, 'mekanism:ultimate_control_circuit', 'mekanism_extras:supreme_control_circuit');
   e.replaceInput({ id: 'mekanism:mekasuit_pants' }, 'mekanism:ultimate_control_circuit', 'mekanism_extras:supreme_control_circuit');

--- a/kubejs/server_scripts/tags.js
+++ b/kubejs/server_scripts/tags.js
@@ -42,6 +42,8 @@ ServerEvents.tags('item', (e) => {
 
   // Curios
   e.add('curios:curio', 'integratedterminals:terminal_storage_portable');
+  e.add('curios:body', 'mekanism:jetpack');
+  e.add('curios:body', 'mekanism:jetpack_armored');
 
   // Chisel Reborn
   Ingredient.of('@chisel').itemIds.forEach((id) => {


### PR DESCRIPTION
The Mekanism jetpack was excessively overpowered in the early game and underwhelming in the mid to late game. To address these issues, I have integrated compatibility with the Curios API and refined its recipe for improved balance.