### PR TITLE
fix: allow for matter tanks uncrafting

### DIFF
--- a/kubejs/server_scripts/Mods/Replication/Recipes.js
+++ b/kubejs/server_scripts/Mods/Replication/Recipes.js
@@ -10,4 +10,6 @@ ServerEvents.recipes((event) => {
   recipes.forEach((recipe) => {
     event.shaped(recipe.output, recipe.pattern, recipe.key).id(recipe.id);
   });
+
+  event.shapeless("replication:matter_tank", "replication:matter_tank");
 });


### PR DESCRIPTION
This pull request allows Matter Tanks matter values to be reset on craft, eliminating the need to delete unwanted tanks