### PR TITLE
fix: disable Anti-Personnel and Confiscation modules in MFFS

### DIFF
--- a/kubejs/server_scripts/removals.js
+++ b/kubejs/server_scripts/removals.js
@@ -18,6 +18,8 @@ const globalItemRemovals = [
   'utilitarian:tiny_charcoal',
   'create:copycat_step',
   'create:copycat_panel',
+  'mffs:anti_personnel_module',
+  'mffs:confiscation_module'
 ];
 
 ServerEvents.recipes((event) => {


### PR DESCRIPTION
This pull request disables the Anti-Personnel and Confiscation modules from Modular Force Field Systems. Currently, the Anti-Personnel module has an unexpected behavior where, when a player is killed, their inventory loot is dropped into the world, while items in the curios slots remain in the grave. This can lead to players intentionally stealing loot from others and other undesirable consequences, effectively breaking the functionality of graves.

The Confiscation module, as the name suggests, allows items to be stolen from players, which isn't ideal for a non-PvP-focused modpack. Personally, I would remove the mod entirely due to various server performance issues and because other mods already provide similar mechanics, such as chunk banning players or preventing mob spawns in certain areas. However, this pull request only disables these two modules.