### PR TITLE
Add Occultism kubejs scripts

### DIFF
--- a/kubejs/server_scripts/Mods/Occultism/Crusher.js
+++ b/kubejs/server_scripts/Mods/Occultism/Crusher.js
@@ -1,0 +1,27 @@
+ServerEvents.recipes((event) => {
+	
+    event.recipes.occultism.crushing(
+        RecipeResult.of("minecraft:gravel", 1),
+        '#c:cobblestones/normal'
+    )
+	
+    event.recipes.occultism.crushing(
+        RecipeResult.of("minecraft:sand", 2),
+        '#c:sandstone/uncolored_blocks'
+    )
+	
+    event.recipes.occultism.crushing(
+        RecipeResult.of("minecraft:red_sand", 2),
+        '#c:sandstone/red_blocks'
+    )
+	
+    event.recipes.occultism.crushing(
+        RecipeResult.of("minecraft:sand", 1),
+        '#c:gravels'
+    )
+	
+    event.recipes.occultism.crushing(
+        RecipeResult.of("minecraft:clay_ball", 4),
+        'minecraft:clay'
+    )
+})

--- a/kubejs/server_scripts/Mods/Occultism/Miner.js
+++ b/kubejs/server_scripts/Mods/Occultism/Miner.js
@@ -1,0 +1,18 @@
+ServerEvents.recipes((event) => {
+
+    event.recipes.occultism.miner(
+        //item, count, weight
+        WeightedRecipeResult.of('modern_industrialization:bauxite_ore', 1, 250),
+        '#occultism:miners/ores'
+    )
+	
+	event.recipes.occultism.miner(
+        WeightedRecipeResult.of('modern_industrialization:deepslate_bauxite_ore', 1, 250),
+        '#occultism:miners/deeps'
+    )
+	
+	event.recipes.occultism.miner(
+        WeightedRecipeResult.of('modern_industrialization:bauxite_block', 1, 90),
+        '#occultism:miners/eldritch'
+    )
+})


### PR DESCRIPTION
This PR adds Bauxite Ore / Deepslate Bauxite Ore to miners, and Bauxite Blocks to Eldritch miners

Additionally, it adds recipes to crusher spirits for Cobblestone->Gravel, Gravel->Sand and Clay->Clay balls

Could use some recipe helpers/fancy kubejs in the future, but these work for the time being