### PR TITLE
refactor: replace global `dyeColors` with `Color.DYE`

### DIFF
--- a/kubejs/server_scripts/Mods/Craftoria/ConflictFixes.js
+++ b/kubejs/server_scripts/Mods/Craftoria/ConflictFixes.js
@@ -24,7 +24,7 @@ ServerEvents.recipes((e) => {
   });
 
   // Fixes Handcrafted Wool Sheets conflicting with Comforts Sleeping Bags
-  global.dyeColors.forEach((wool) => {
+  Color.DYE.forEach((wool) => {
     e.remove({ type: 'minecraft:crafting_shaped', output: `handcrafted:${wool}_sheet` });
 
     // Sheets

--- a/kubejs/server_scripts/tags.js
+++ b/kubejs/server_scripts/tags.js
@@ -122,7 +122,7 @@ ServerEvents.tags('block', (e) => {
   e.add('ae2:blacklisted/spatial', ['justdirethings:time_crystal_budding_block']);
   e.add('mekanism:cardboard_blacklist', ['justdirethings:time_crystal_budding_block']);
 
-  global.dyeColors.forEach((color) => {
+  Color.DYE.forEach((color) => {
     e.add('c:glass_blocks', `#chipped:${color}_stained_glass`);
     e.add('c:glass_panes', `#chipped:${color}_stained_glass_pane`);
   });

--- a/kubejs/startup_scripts/Globals.js
+++ b/kubejs/startup_scripts/Globals.js
@@ -1,9 +1,5 @@
 // priority: 0
 
-const $DyeColor = Java.loadClass('net.minecraft.world.item.DyeColor');
-
-global.dyeColors = $DyeColor.values().map((color) => color.toString().toLowerCase());
-
 /**
  * Enables a few scripts that are only useful for development.
  * Make sure to disable this in production/before pushing to git.


### PR DESCRIPTION
This pull request simplifies dye color handling by using the `Color` namespace.