### PR TITLE
Add base editor configuration files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# .editorconfig for code formatting and line endings
+
+# Top-most EditorConfig file
+root = true
+
+# Default settings for all files
+[*]
+charset = utf-8
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+# File-specific line endings and types
+[*.sh]
+end_of_line = lf
+
+[*.bat]
+end_of_line = crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Declare files that will always have CRLF line endings on checkout.
+*.sh text eol=lf
+*.bat text eol=crlf
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,10 @@
+{
+    "trailingComma": "none",
+    "tabWidth": 4,
+    "semi": true,
+    "arrowParens": "avoid",
+    "singleQuote": true,
+    "printWidth": 90,
+    "bracketSpacing": true,
+    "endOfLine": "auto"
+}

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,6 +1,6 @@
 {
-    "trailingComma": "none",
-    "tabWidth": 4,
+    "trailingComma": "es5",
+    "tabWidth": 2,
     "semi": true,
     "arrowParens": "avoid",
     "singleQuote": true,


### PR DESCRIPTION
This pull requests adds standard configuration files to maintain consistent code formatting and editor settings:
- `.prettierrc.json` for code formatting rules
- `.gitattributes` for consistent line endings handling
- `.editorconfig` for basic editor preferences