### PR TITLE
feat: explicitly set craftoria mod name to "Craftoria"

### DIFF
--- a/kubejs/startup_scripts/Globals.js
+++ b/kubejs/startup_scripts/Globals.js
@@ -37,3 +37,5 @@ global.customMIMachines = [
     casing: 'sky_stone_brick_casing',
   },
 ];
+
+Platform.setModName("craftoria", "Craftoria");


### PR DESCRIPTION
This pull request updates the Craftoria mod name(currently the modid) from `craftoria` to `Craftoria` using the Platform namespace.