### PR TITLE
fix: update armored jetpack recipe to use diamond dusts tag

### DIFF
--- a/kubejs/server_scripts/Mods/Mekanism/Recipes.js
+++ b/kubejs/server_scripts/Mods/Mekanism/Recipes.js
@@ -164,15 +164,15 @@ ServerEvents.recipes((e) => {
     D: 'mekanism_extras:cosmic_control_circuit',
   }).id('mekaweapons:bow_riser');
 
-  e.shaped('mekanism:jetpack', ['ADA','BCB',' B '], {
+  e.shaped('mekanism:jetpack', ['ADA', 'BCB', ' B '], {
     A: 'modern_industrialization:steel_ingot',
     B: 'modern_industrialization:tin_double_ingot',
     C: 'mekanism:ultimate_chemical_tank',
     D: 'mekanism:ultimate_control_circuit',
   }).id('mekanism:jetpack');
 
-  e.shaped('mekanism:jetpack_armored', ['A A','BCB',' D '], {
-    A: 'mekanism:dust_diamond',
+  e.shaped('mekanism:jetpack_armored', ['A A', 'BCB', ' D '], {
+    A: '#c:dusts/diamond',
     B: 'modern_industrialization:bronze_double_ingot',
     C: 'modern_industrialization:steel_block',
     D: 'mekanism:jetpack',


### PR DESCRIPTION
This pull request replaces mekanism diamond dust tag in the armored jetpack recipe. Fixing the recipe not working.