### PR TITLE
Add mob blacklist tag and integrate with Mob Duplicator blacklist

### DIFF
--- a/kubejs/server_scripts/tags.js
+++ b/kubejs/server_scripts/tags.js
@@ -169,9 +169,11 @@ ServerEvents.tags('fluid', (e) => {
 });
 
 ServerEvents.tags('entity_type', (e) => {
+  e.add("craftoria:mob_blacklist", ['artifacts:mimic', 'minecraft:warden', '#c:bosses', /^occultism:(?!possessed).*$/, '#neoforge:bosses'])
+
   e.add('ftbchunks:entity_interact_whitelist', ['minecraft:villager', 'minecraft:wandering_trader']);
 
-  e.add('mob_grinding_utils:no_swab', ['artifacts:mimic', 'minecraft:warden', '#c:bosses', /^occultism:(?!possessed).*$/, '#neoforge:bosses']);
+  e.add('mob_grinding_utils:no_swab', "#craftoria:mob_blacklist");
 
   e.add('industrialforegoing:mob_crusher_blacklist', ['#c:bosses', '#neoforge:bosses']);
 });

--- a/kubejs/server_scripts/tags.js
+++ b/kubejs/server_scripts/tags.js
@@ -176,6 +176,8 @@ ServerEvents.tags('entity_type', (e) => {
   e.add('mob_grinding_utils:no_swab', "#craftoria:mob_blacklist");
 
   e.add('industrialforegoing:mob_crusher_blacklist', ['#c:bosses', '#neoforge:bosses']);
+
+  e.add("industrialforegoing:mob_duplicator_blacklist", "#craftoria:mob_blacklist");
 });
 
 ServerEvents.tags('enchantment', (e) => {


### PR DESCRIPTION
This pull request introduces the `craftoria:mob_blacklist` tag and integrates it with Industrial Foregoing's Mob Duplicator blacklist.