### PR TITLE
feat: whitelist JAMD Nether for IF laser drilling ancient debris recipe

### DIFF
--- a/kubejs/data/industrialforegoing/recipe/laser_drill_ore/ancient_debris.json
+++ b/kubejs/data/industrialforegoing/recipe/laser_drill_ore/ancient_debris.json
@@ -1,0 +1,24 @@
+{
+  "type": "industrialforegoing:laser_drill_ore",
+  "catalyst": {
+    "item": "industrialforegoing:brown_laser_lens"
+  },
+  "output": {
+    "item": "minecraft:ancient_debris"
+  },
+  "rarity": [
+    {
+      "biome_filter": {
+        "blacklist": [],
+        "whitelist": []
+      },
+      "depth_max": 20,
+      "depth_min": 1,
+      "dimension_filter": {
+        "blacklist": [],
+        "whitelist": ["minecraft:the_nether", "jamd:nether"]
+      },
+      "weight": 1
+    }
+  ]
+}


### PR DESCRIPTION
This pull request adds the JAMD Nether dimension to the whitelist for the IF laser drilling ancient debris recipe.
