### PR TITLE
Unify coffee beans between Actually Additions and Rustic Delight

### DIFF
--- a/kubejs/data/actuallyadditions/advancement/pickup_coffee.json
+++ b/kubejs/data/actuallyadditions/advancement/pickup_coffee.json
@@ -1,0 +1,29 @@
+{
+  "parent": "actuallyadditions:craft_coal_generator",
+  "criteria": {
+    "coffee_beans": {
+      "conditions": {
+        "items": [
+          {
+            "items": "rusticdelight:coffee_beans"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    }
+  },
+  "display": {
+    "description": {
+      "translate": "achievement.actuallyadditions.pickUpCoffee.desc"
+    },
+    "icon": {
+      "count": 1,
+      "id": "rusticdelight:coffee_beans"
+    },
+    "title": {
+      "translate": "achievement.actuallyadditions.pickUpCoffee"
+    }
+  },
+  "requirements": [["coffee_beans"]],
+  "sends_telemetry_event": true
+}

--- a/kubejs/server_scripts/tags.js
+++ b/kubejs/server_scripts/tags.js
@@ -17,6 +17,8 @@ ServerEvents.tags('item', (e) => {
   e.add('c:crops/garlic', 'dumplings_delight:garlic');
   e.add('c:crops/green_onion', 'dumplings_delight:greenonion');
 
+  e.add("actuallyadditions:coffee_beans", "rusticdelight:coffee_beans")
+
   e.remove('c:crops/garlic', 'dumplings_delight:garlic_clove');
   e.remove('c:foods/garlic', 'dumplings_delight:garlic_clove');
 


### PR DESCRIPTION
This pull request unifies the tags for coffee beans between Actually Additions and Rustic Delight, resolving the issue with the coffee maker recipe. Also updates the advancement for picking up coffee beans to reference the Rustic Delight tag instead of the Actually Additions tag.