### PR TITLE
fix sophisticated storage controller recipe accepting only one type of chest/barrel

### DIFF
--- a/kubejs/server_scripts/Mods/SophisticatedStorage/Recipes.js
+++ b/kubejs/server_scripts/Mods/SophisticatedStorage/Recipes.js
@@ -1,0 +1,9 @@
+ServerEvents.recipes((e) => {
+    // Sophisticated Storage Controller
+    e.shaped('sophisticatedstorage:controller', ['SCS', 'PBP', 'SCS'], {
+        B: '#craftoria:storage/wooden',
+        C: 'minecraft:comparator',
+        P: '#minecraft:planks',
+        S: '#c:stones',
+    }).id('sophisticatedstorage:controller');
+});

--- a/kubejs/server_scripts/tags.js
+++ b/kubejs/server_scripts/tags.js
@@ -67,11 +67,13 @@ ServerEvents.tags('item', (e) => {
   ]);
 
   // Modern Industrialization hammers
-
   e.add('modern_industrialization:forge_hammer_tools', [
     'craftoria:flimsy_hammer',
     /^justhammers:(stone|iron|gold|diamond|netherite)_(impact|reinforced|reinforced_impact|destructor)_hammer$/,
   ]);
+
+  // Wooden Tier Storage
+  e.add('craftoria:storage/wooden', ['#c:chests/wooden', '#c:barrels/wooden',]);
 
   // Some tag fixes
   e.add('minecraft:swords', ['wstweaks:blaze_blade', 'wstweaks:lava_blade', 'industrialforegoing:infinity_hammer']);


### PR DESCRIPTION
This pull request fixes an issue where the Sophisticated Storage controller recipe only accepted one specific type of wooden chest or barrel from Sophisticated Storage. Now, the recipe works with all the different types available. This fix addresses issue #495 .