### PR TITLE
Make mekanism pellets and yellow cake edible

### DIFF
--- a/kubejs/server_scripts/Mods/Mekanism/Edibles.js
+++ b/kubejs/server_scripts/Mods/Mekanism/Edibles.js
@@ -31,4 +31,17 @@ ItemEvents.foodEaten((event) => {
             player.potionEffects.add(effect, 600, 5, false, false);
         });
     }
+    if (item.id === 'mekanism:pellet_antimatter') {
+        let blackHoleEntity = level.createEntity('irons_spellbooks:black_hole');
+        // Set the entity's NBT data to make it bigger and last shorter
+        blackHoleEntity.setNbt({Damage: 0, Radius: 15, Age: 450});
+
+        // Summon black hole entity at player position and apply effects
+        player.tell(Text.red('MATTER IS COMPRESSING AROUND YOU!').bold());
+        pelletsEffects.forEach((effect) => {
+            player.potionEffects.add(effect, 600, 5, false, false);
+        });
+        blackHoleEntity.spawn();
+        blackHoleEntity.setPos(player.x, player.y, player.z);
+    }
 });

--- a/kubejs/server_scripts/Mods/Mekanism/Edibles.js
+++ b/kubejs/server_scripts/Mods/Mekanism/Edibles.js
@@ -1,0 +1,34 @@
+
+ItemEvents.foodEaten((event) => {
+    let { player, item } = event;
+    // Dont eat these at home, kids!
+    // Add message when eating plutonium, polonium and yellow cake
+    // then kill the player
+    
+    const pelletsEffects = [
+        'minecraft:nausea',
+        'relics:anti_heal',
+        'relics:paralysis',
+        'minecraft:glowing',
+        'minecraft:darkness',
+        'apothic_attributes:bleeding'
+    ];
+    if (item.id === 'mekanism:pellet_plutonium') {
+        player.tell(Text.red('Plutonium is not good for you!'));
+        pelletsEffects.forEach((effect) => {
+            player.potionEffects.add(effect, 600, 5, false, false);
+        });
+    }
+    if (item.id === 'mekanism:pellet_polonium') {
+        player.tell(Text.red('Polonium is not good for you!'));
+        pelletsEffects.forEach((effect) => {
+            player.potionEffects.add(effect, 600, 5, false, false);
+        });
+    }
+    if (item.id === 'mekanism:yellow_cake_uranium') {
+        player.tell(Text.red('Cake is a lie! Expecially this one...'));
+        pelletsEffects.forEach((effect) => {
+            player.potionEffects.add(effect, 600, 5, false, false);
+        });
+    }
+});

--- a/kubejs/server_scripts/Mods/Mekanism/Edibles.js
+++ b/kubejs/server_scripts/Mods/Mekanism/Edibles.js
@@ -1,10 +1,9 @@
-
 ItemEvents.foodEaten((event) => {
-    let { player, item } = event;
+    let { player, item, level, server } = event;
     // Dont eat these at home, kids!
     // Add message when eating plutonium, polonium and yellow cake
     // then kill the player
-    
+
     const pelletsEffects = [
         'minecraft:nausea',
         'relics:anti_heal',
@@ -13,23 +12,35 @@ ItemEvents.foodEaten((event) => {
         'minecraft:darkness',
         'apothic_attributes:bleeding'
     ];
+    
+    let pelletsEffectDuration = 6000; // 5 minutes
+
+    let preventImmunity = () => {
+        server.scheduleInTicks(400, () => {player.tell(Text.white("You feel immortal").bold());});
+        server.scheduleInTicks(500, () => {player.tell(Text.darkRed("But it won't last for long...").bold());});
+        server.scheduleInTicks(600, () => {player.kill();});
+    };
+
     if (item.id === 'mekanism:pellet_plutonium') {
         player.tell(Text.red('Plutonium is not good for you!'));
         pelletsEffects.forEach((effect) => {
-            player.potionEffects.add(effect, 600, 5, false, false);
+            player.potionEffects.add(effect, pelletsEffectDuration, 5, false, false);
         });
+        preventImmunity();
     }
     if (item.id === 'mekanism:pellet_polonium') {
         player.tell(Text.red('Polonium is not good for you!'));
         pelletsEffects.forEach((effect) => {
-            player.potionEffects.add(effect, 600, 5, false, false);
+            player.potionEffects.add(effect, pelletsEffectDuration, 5, false, false);
         });
+        preventImmunity();
     }
     if (item.id === 'mekanism:yellow_cake_uranium') {
         player.tell(Text.red('Cake is a lie! Expecially this one...'));
         pelletsEffects.forEach((effect) => {
-            player.potionEffects.add(effect, 600, 5, false, false);
+            player.potionEffects.add(effect, pelletsEffectDuration, 5, false, false);
         });
+        preventImmunity();
     }
     if (item.id === 'mekanism:pellet_antimatter') {
         let blackHoleEntity = level.createEntity('irons_spellbooks:black_hole');
@@ -39,9 +50,10 @@ ItemEvents.foodEaten((event) => {
         // Summon black hole entity at player position and apply effects
         player.tell(Text.red('MATTER IS COMPRESSING AROUND YOU!').bold());
         pelletsEffects.forEach((effect) => {
-            player.potionEffects.add(effect, 600, 5, false, false);
+            player.potionEffects.add(effect, pelletsEffectDuration, 5, false, false);
         });
         blackHoleEntity.spawn();
         blackHoleEntity.setPos(player.x, player.y, player.z);
+        preventImmunity();
     }
 });

--- a/kubejs/startup_scripts/Custom/Items.js
+++ b/kubejs/startup_scripts/Custom/Items.js
@@ -39,6 +39,7 @@ ItemEvents.modification(event => {
   const pelletsEdible = [
     'mekanism:pellet_plutonium',
     'mekanism:pellet_polonium',
+    'mekanism:pellet_antimatter',
     'mekanism:yellow_cake_uranium'
   ]
 

--- a/kubejs/startup_scripts/Custom/Items.js
+++ b/kubejs/startup_scripts/Custom/Items.js
@@ -33,3 +33,23 @@ StartupEvents.registry('item', (e) => {
     .tag(`craftoria:replicator_1_blacklist`)
     .rarity('Epic');
 });
+
+ItemEvents.modification(event => {
+
+  const pelletsEdible = [
+    'mekanism:pellet_plutonium',
+    'mekanism:pellet_polonium',
+    'mekanism:yellow_cake_uranium'
+  ]
+
+  pelletsEdible.forEach((pellet) => {
+    event.modify(pellet, item => {
+      item.food = {
+        nutrition: 1000,
+        saturation: 1000,
+        eatSeconds: 2,
+        canAlwaysEat: true
+      };
+    });
+  });
+});


### PR DESCRIPTION
Allow players to eat polonium/plutonium pellets as well as yellow cake