### PR TITLE
fix: skip matter values calculation for GoE gates

### DIFF
--- a/kubejs/server_scripts/tags.js
+++ b/kubejs/server_scripts/tags.js
@@ -96,6 +96,11 @@ ServerEvents.tags('item', (e) => {
     /^justhammers:(stone|iron|gold|diamond|netherite)_(impact|reinforced|reinforced_impact|destructor)_hammer$/,
   ]);
 
+  // Replication
+  e.add("replication:skip_calculation", [
+    "gateways:gate_pearl",
+  ])
+
   // Wooden Tier Storage
   e.add('craftoria:storage/wooden', ['#c:chests/wooden', '#c:barrels/wooden']);
 


### PR DESCRIPTION
This pull request fixes an issue where Gateways of Eternity gates produced invalid gate pearls during replication(Replication mod). The replication process does not preserve NBT data, which is required for these items to function correctly.

Fixes this discord bug thread:
https://discord.com/channels/570630340075454474/1360776942038810795