### PR TITLE
fix: remove Actually Additions coffee beans from FFB market

### DIFF
--- a/kubejs/server_scripts/Mods/FarmingForBlockheads/market.js
+++ b/kubejs/server_scripts/Mods/FarmingForBlockheads/market.js
@@ -35,6 +35,9 @@ ServerEvents.recipes(e => {
 
     // Ars Nouveau
     'ars_nouveau:magebloom_crop',
+
+    // Actually Additions
+    'actuallyadditions:coffee_beans',
   ];
 
   Ingredient.of('#minecraft:saplings').stacks.forEach(sapling => {


### PR DESCRIPTION
This pull request removes Actually Additions coffee beans from the FFB market, as they've been unified with Rustic Delight's and now have no usage or recipes.