### PR TITLE
refactor(docs): update and add JSDoc types

### DIFF
--- a/kubejs/server_scripts/EMIThings/Hide.js
+++ b/kubejs/server_scripts/EMIThings/Hide.js
@@ -1,4 +1,5 @@
 RecipeViewerEvents.removeEntries('item', event => {
+  /** @type {Special.Item[]} */
   let hideItems = [];
 
   hideItems.forEach(item => {

--- a/kubejs/server_scripts/EMIThings/info.js
+++ b/kubejs/server_scripts/EMIThings/info.js
@@ -1,6 +1,7 @@
 // Currently adding information to EMI adds it twice, due to it also being added to JEI.
 RecipeViewerEvents.addInformation('fluid', e => {
-  let fluidEntries = {
+  /** @type {Record<Special.Fluid, string[]>} */
+  const entries = {
     'justdirethings:unstable_portal_fluid_source': [
       'This fluid is used to make (stable)portal fluid.',
       'It must be made in a vanilla End Biome,',
@@ -8,13 +9,14 @@ RecipeViewerEvents.addInformation('fluid', e => {
     ],
   };
 
-  for (let [fluid, info] in fluidEntries) {
+  for (let [fluid, info] of Object.entries(entries)) {
     e.add(fluid, info);
   }
 });
 
 RecipeViewerEvents.addInformation('item', e => {
-  let entries = {
+  /** @type {Record<Special.Item, string[]>} */
+  const entries = {
     'cursedearth:cursed_earth': [
       `Can be acquired by sneaking and using a Wither Rose on Dirt.`,
       `Spawns hostile mobs at a fast pace.`,
@@ -38,7 +40,7 @@ RecipeViewerEvents.addInformation('item', e => {
     ],
   };
 
-  for (let [item, info] in entries) {
+  for (let [item, info] of Object.entries(entries)) {
     if (info.length > 0)
       for (let i = 0; i < info.length - 1; i++) {
         info[i] += '\n';

--- a/kubejs/server_scripts/Mods/AE2/MegaCells.js
+++ b/kubejs/server_scripts/Mods/AE2/MegaCells.js
@@ -1,4 +1,5 @@
 ServerEvents.generateData('after_mods', event => {
+  /** @type {Record<Special.Item, Special.Item>} */
   const overrides = {
     'actuallyadditions:black_quartz': 'actuallyadditions:black_quartz_block',
     'minecraft:brick': 'minecraft:bricks',

--- a/kubejs/server_scripts/Mods/Apothic/Spawners.js
+++ b/kubejs/server_scripts/Mods/Apothic/Spawners.js
@@ -1,6 +1,6 @@
 ServerEvents.recipes(e => {
   /**
-   * @description Apothic Spawners modifier recipe
+   * Apothic Spawners modifier recipe
    * @param {$Ingredient_} item Item used for the modifier. Required.
    * @param {Object} stats Stats for the main recipe. {value, limit} Required.
    * @param {Special.ApothicSpawnersSpawnerStat} spawnerModifier Spawner modifier type. Required.

--- a/kubejs/server_scripts/Mods/HostileNeuralNetworks/DataModels.js
+++ b/kubejs/server_scripts/Mods/HostileNeuralNetworks/DataModels.js
@@ -7,7 +7,7 @@
  * @property {number} [display.y_offset]
  * @property {number} simCost
  * @property {Special.Item} baseDrop
- * @property {(Special.Item|Special.ItemTag)[]} fabricatorDrops
+ * @property {($ItemStack_|Special.ItemTag)[]} fabricatorDrops
  * @property {Object} tierData
  * @property {number} [tierData.faulty]
  * @property {number} [tierData.basic]
@@ -76,7 +76,7 @@ function generateModelData(entityId, data) {
 }
 
 ServerEvents.generateData('after_mods', event => {
-  /**@type {Record<Special.EntityType, DataModel>} */
+  /** @type {Record<Special.EntityType, DataModel>} */
   const dataModels = {
     'artifacts:mimic': {
       simCost: 2560,

--- a/kubejs/server_scripts/Mods/ModernIndustrialization/Info.js
+++ b/kubejs/server_scripts/Mods/ModernIndustrialization/Info.js
@@ -1,4 +1,5 @@
 RecipeViewerEvents.addInformation('item', e => {
+  /** @type {Record<Special.Item, string[]>} */
   let entries = {
     // Add machine information here
     'modern_industrialization:replicator_1': [

--- a/kubejs/server_scripts/Mods/ModernIndustrialization/QoL.js
+++ b/kubejs/server_scripts/Mods/ModernIndustrialization/QoL.js
@@ -12,7 +12,8 @@ ServerEvents.recipes(e => {
       .id(`craftoria:mi/mixer/${item.split(':')[1]}`);
   };
 
-  [
+  /** @type {Special.Item[]} */
+  const cobbleItems = [
     // Vanilla
     'minecraft:cobblestone',
     'minecraft:granite',
@@ -33,7 +34,9 @@ ServerEvents.recipes(e => {
     'eternal_starlight:abysslate',
     'eternal_starlight:thermabysslate',
     'eternal_starlight:cryobysslate',
-  ].forEach(cobbleGen);
+  ];
+
+  cobbleItems.forEach(cobbleGen);
 
   alloy_smelter(4, 200)
     .itemIn('#morered:red_alloyable_ingots')

--- a/kubejs/server_scripts/Mods/ModernIndustrialization/Quarry.js
+++ b/kubejs/server_scripts/Mods/ModernIndustrialization/Quarry.js
@@ -13,10 +13,10 @@ ServerEvents.recipes(event => {
 
   /**
    * Modern Industrialization Quarry Recipe
-   * @param {Array} input Add the input item, amount and probability(1 being 100%, 0.01 being 1%) as an array.
-   * @param {Array} outputs Add the output items, amount and probability(1 being 100%, 0.01 being 1%) as an array of arrays.
-   * @param {int} eu EU/t consumed by the machine.
-   * @param {int} duration Duration of the recipe in ticks.
+   * @param {MIItem} input Add the input item, amount and probability(1 being 100%, 0.01 being 1%) as an array.
+   * @param {MIItem[]} outputs Add the output items, amount and probability(1 being 100%, 0.01 being 1%) as an array of arrays.
+   * @param {number} eu EU/t consumed by the machine.
+   * @param {number} duration Duration of the recipe in ticks.
    * @param {boolean} overwrite Should the recipe overwrite the existing one. (Default: true) Usefull for updating recipes.
    */
   let MIQuarry = (input, outputs, eu, duration, overwrite) => {

--- a/kubejs/server_scripts/Mods/ModernIndustrialization/Recipes.js
+++ b/kubejs/server_scripts/Mods/ModernIndustrialization/Recipes.js
@@ -56,7 +56,8 @@ ServerEvents.recipes(e => {
   let madeCuttingRecipeFor = [];
   Ingredient.of('#minecraft:logs').itemIds.forEach(id => {
     if ((!id.includes('log') && !id.includes('stem')) || id.includes('stripped')) return;
-    const { modID, itemId } = { modID: id.split(':')[0], itemId: id.split(':')[1] };
+    /** @type {[Special.Mod, string]} */
+    const [modID, itemId] = id.split(':');
 
     if (modID === 'minecraft') return;
 

--- a/kubejs/server_scripts/Mods/ModernIndustrialization/ReplicatorBlacklist.js
+++ b/kubejs/server_scripts/Mods/ModernIndustrialization/ReplicatorBlacklist.js
@@ -1,6 +1,6 @@
 ServerEvents.tags('item', e => {
   /**
-   * @description Blacklist for both Replicator Mk I and Mk II.
+   * Blacklist for both Replicator Mk I and Mk II.
    * @type {$Ingredient_[]}
    */
   const replicatorBlacklist = [
@@ -35,7 +35,7 @@ ServerEvents.tags('item', e => {
   ];
 
   /**
-   * @description Blacklist for Replicator Mk II.
+   * Blacklist for Replicator Mk II.
    * @type {$Ingredient_[]}
    */
   const replicator_2_blacklist = [
@@ -162,7 +162,7 @@ ServerEvents.tags('item', e => {
   ].concat(replicatorBlacklist);
 
   /**
-   * @description Blacklist for Replicator Mk I.
+   * Blacklist for Replicator Mk I.
    * @type {$Ingredient_[]}
    */
   const replicator_1_blacklist = [
@@ -205,6 +205,7 @@ ServerEvents.tags('item', e => {
     'modern_industrialization:quantum_circuit_board',
     'modern_industrialization:quantum_machine_casing',
   ];
+
   /** @type {$Ingredient_[]} */
   const replicator_1_exclusions = [
     'modern_industrialization:quantum_circuit',

--- a/kubejs/server_scripts/Mods/Powah/Recipes.js
+++ b/kubejs/server_scripts/Mods/Powah/Recipes.js
@@ -1,5 +1,6 @@
 ServerEvents.recipes(e => {
   let energizing = e.recipes.powah.energizing;
+
   e.remove({ id: 'powah:crafting/reactor_starter' });
 
   e.shaped('powah:reactor_starter', ['ABA', 'BCB', 'ABA'], {

--- a/kubejs/server_scripts/helpers/ae2.js
+++ b/kubejs/server_scripts/helpers/ae2.js
@@ -6,7 +6,7 @@ function AE2Helper(event) {
   /**
    * Generate a recipe ID based on output and recipe type
    * @param {string} type
-   * @param {$Item_} output
+   * @param {Special.Item} output
    * @returns {string} The generated recipe ID
    */
   let makeRecipeId = (type, output) => {
@@ -18,9 +18,9 @@ function AE2Helper(event) {
   return {
     /**
      * ExtendedAE Crystal Assembler Recipe
-     * @param {$Item_} output
+     * @param {$ItemStack_} output
      * @param {$Ingredient_[]} inputs
-     * @param {$Fluid_} [fluid]
+     * @param {Special.Fluid} [fluid]
      * @param {Special.RecipeId} [recipeID] The recipe ID, can be used to overwrite recipes (optional, default is generated based on recipe parameters).
      */
     crystalAssembler(output, inputs, fluid, recipeID) {
@@ -49,7 +49,7 @@ function AE2Helper(event) {
 
     /**
      * ExtendedAE Circuit Cutter Recipe
-     * @param {$Item_} output
+     * @param {$ItemStack_} output
      * @param {$Ingredient_} input
      * @param {Special.RecipeId} [recipeID] The recipe ID, can be used to overwrite recipes (optional, default is generated based on recipe parameters).
      */
@@ -91,7 +91,7 @@ function AE2Helper(event) {
     /**
      * AE2 Inscriber Recipe
      * @param {$InscriberProcessType_} mode
-     * @param {$Item_} output
+     * @param {$ItemStack_} output
      * @param {$Ingredient_} middle
      * @param {$Ingredient_} [top]
      * @param {$Ingredient_} [bottom]

--- a/kubejs/server_scripts/helpers/ars_nouveau.js
+++ b/kubejs/server_scripts/helpers/ars_nouveau.js
@@ -5,7 +5,7 @@
 function ArsNouveauHelper(event) {
   /**
    * Generate a recipe ID based on output and recipe type
-   * @param {$Item_} output
+   * @param {Special.Item} output
    * @param {string} type
    * @returns {string} The generated recipe ID
    */
@@ -17,7 +17,7 @@ function ArsNouveauHelper(event) {
 
   return {
     /**
-     * @description Creates a recipe for the Ars Nouveau Enchanting Apparatus.
+     * Creates a recipe for the Ars Nouveau Enchanting Apparatus.
      * @param {$ItemStack_} output The output item (e.g., '4x minecraft:chest'). Required.
      * @param {$ItemStack_} input The input item (e.g., 'minecraft:cobblestone'). Required.
      * @param {$ItemStack_[]} pedestalItems The pedestal items (e.g., ['minecraft:stick', 'minecraft:stick']). Required. Max 8.
@@ -56,7 +56,7 @@ function ArsNouveauHelper(event) {
     },
 
     /**
-     * @description Creates a recipe for the Ars Nouveau Imbuement Chamber.
+     * Creates a recipe for the Ars Nouveau Imbuement Chamber.
      * @param {$ItemStack_} output The output item (e.g., '4x minecraft:chest'). Required.
      * @param {$ItemStack_} input The input item (e.g., 'minecraft:cobblestone'). Required.
      * @param {$ItemStack_[]} pedestalItems The pedestal items (e.g., ['minecraft:stick', 'minecraft:stick']). Required. Max 8.
@@ -92,7 +92,7 @@ function ArsNouveauHelper(event) {
     },
 
     /**
-     * @description Creates a recipe for the Ars Nouveau Glyph.
+     * Creates a recipe for the Ars Nouveau Glyph.
      * @param {$ItemStack_} output The output item (e.g., '4x minecraft:chest'). Required.
      * @param {$ItemStack_[]} inputs The input items (e.g., ['minecraft:cobblestone', 'minecraft:stone']). Required.
      * @param {number} [xpCost] The XP cost (e.g., 100). (optional, default is 0).

--- a/kubejs/server_scripts/helpers/create.js
+++ b/kubejs/server_scripts/helpers/create.js
@@ -1,6 +1,6 @@
 /**
  * @typedef {($Ingredient_|$FluidIngredient_)[]|($Ingredient_|$FluidIngredient_)} CreateIngredients
- * @typedef {($Item_|$Fluid_)[]|($Item_|$Fluid_)} CreateResults
+ * @typedef {(Special.Item|Special.Fluid)[]|(Special.Item|Special.Fluid)} CreateResults
  */
 
 /**

--- a/kubejs/server_scripts/helpers/industrial_foregoing.js
+++ b/kubejs/server_scripts/helpers/industrial_foregoing.js
@@ -40,7 +40,7 @@ function IndustrialForegoingHelper(event) {
 
   return {
     /**
-     * @param {$Fluid_} fluidOutput
+     * @param {Special.Fluid} fluidOutput
      * @param {Special.BlockTag[] | Special.Block[]} blockInput
      * @param {Special.Block} blockOutput
      * @param {number} [breakChance=0]
@@ -62,11 +62,11 @@ function IndustrialForegoingHelper(event) {
     },
 
     /**
-     * @param {$Item_} itemOutput
+     * @param {$ItemStack_} itemOutput
      * @param {$Ingredient_[]} itemInputs
      * @param {number} [processingTime=100]
      * @param {$FluidIngredient_} [fluidInput]
-     * @param {$Fluid_} [fluidOutput]
+     * @param {Special.Fluid} [fluidOutput]
      * @param {Special.RecipeId} [recipeID] The recipe ID, can be used to overwrite recipes (optional, default is generated based on recipe parameters).
      */
     dissolutionChamber(itemOutput, itemInputs, processingTime, fluidInput, fluidOutput, recipeID) {
@@ -97,8 +97,8 @@ function IndustrialForegoingHelper(event) {
     },
 
     /**
-     * @param {$Item_} itemOutput
-     * @param {$Item_} catalyst
+     * @param {Special.Item} itemOutput
+     * @param {Special.Item} catalyst
      * @param {LaserDrillRarity[] | LaserDrillRarity} [rarityList]
      * @param {Special.RecipeId} [recipeID] The recipe ID, can be used to overwrite recipes (optional, default is generated based on recipe parameters).
      */

--- a/kubejs/server_scripts/helpers/mekanism.js
+++ b/kubejs/server_scripts/helpers/mekanism.js
@@ -6,7 +6,7 @@ function MekanismHelper(event) {
   /**
    * Generate a recipe ID based on output, input and recipe type
    * @param {string} type
-   * @param {$Item_} output
+   * @param {Special.Item} output
    * @param {$Ingredient_} input
    * @returns {string} The generated recipe ID
    */
@@ -77,7 +77,7 @@ function MekanismHelper(event) {
     /**
      * @param {$ItemStack_} itemOutput
      * @param {[$ItemStack_[], number]} itemInputListWithCount
-     * @param {$Fluid_} fluidInput
+     * @param {Special.Fluid} fluidInput
      * @param {$Chemical_} chemicalOutput
      * @param {$Chemical_} chemicalInput
      * @param {number} [duration]
@@ -127,7 +127,7 @@ function MekanismHelper(event) {
 
     /**
      * @param {$Chemical_} chemicalInput
-     * @param {$Fluid_} fluidId
+     * @param {Special.Fluid} fluidId
      * @param {Special.RecipeId} [recipeID] The recipe ID, can be used to overwrite recipes (optional, default is generated based on recipe parameters).
      */
 

--- a/kubejs/server_scripts/helpers/modern_industrialization.js
+++ b/kubejs/server_scripts/helpers/modern_industrialization.js
@@ -1,13 +1,13 @@
 /**
- * @typedef {[$Item_, number, number?]} MIItem A tuple of [item, amount, probability?]
- * @typedef {[$Fluid_, number, number?]} MIFluid A tuple of [fluid, amount, probability?]
+ * @typedef {[Special.Item, number, number?]} MIItem A tuple of [item, amount, probability?]
+ * @typedef {[Special.Fluid, number, number?]} MIFluid A tuple of [fluid, amount, probability?]
  */
 
 /**
  * @typedef {Object} MIRecipeInput
- * @property {$Item_} [item] - The item ID
+ * @property {Special.Item} [item] - The item ID
  * @property {string} [tag] - The item tag
- * @property {$Fluid_} [fluid] - The fluid ID
+ * @property {Special.Fluid} [fluid] - The fluid ID
  * @property {number} amount - The amount required/produced
  * @property {number} [probability] - The probability (optional)
  */

--- a/kubejs/server_scripts/removals.js
+++ b/kubejs/server_scripts/removals.js
@@ -1,3 +1,4 @@
+/** @type {Special.Item[]} */
 const globalItemRemovals = [
   'megacells:mega_interface',
   'megacells:cable_mega_interface',
@@ -23,6 +24,7 @@ const globalItemRemovals = [
 ];
 
 ServerEvents.recipes(event => {
+  /** @type {Special.RecipeId[]} */
   const id = [
     'appflux:inscriber/crush_diamond',
     'appflux:inscriber/crush_emerald',
@@ -35,6 +37,7 @@ ServerEvents.recipes(event => {
     'supplementaries:sus_sand',
   ];
 
+  /** @type {Special.Item[]} */
   const output = [];
 
   id.forEach(id => {

--- a/kubejs/server_scripts/unify/Knife.js
+++ b/kubejs/server_scripts/unify/Knife.js
@@ -1,5 +1,7 @@
 {
+  /** @type {Special.Mod[]} */
   let modWhitelist = ['farmersdelight', 'moredelight', 'arsdelight', 'twilightdelight', 'ends_delight'];
+  /** @type {Special.Item[]} */
   let itemWhitelist = ['aquaculture:neptunium_fillet_knife'];
 
   ServerEvents.recipes(e => {

--- a/kubejs/server_scripts/unify/general.js
+++ b/kubejs/server_scripts/unify/general.js
@@ -99,8 +99,8 @@ ServerEvents.tags('item', e => {
 
 ServerEvents.recipes(e => {
   const ars = ArsNouveauHelper(e);
-  const ae2 = AE2Helper(e);
-
+  const ae = AE2Helper(e);
+  /** @type {Special.RecipeSerializer[]} */
   let replaceFilters = ['minecraft:crafting_shaped', 'minecraft:crafting_shapeless', 'minecraft:smelting', 'minecraft:blasting'];
 
   let tryReplace = replace => {
@@ -232,5 +232,5 @@ ServerEvents.recipes(e => {
     'ars_elemental:glyph_arc_projectile'
   );
 
-  ae2.inscriber('inscribe', 'ae2:ender_dust', '#c:ender_pearls', null, null, 'ae2:inscriber/ender_dust');
+  ae.inscriber('inscribe', 'ae2:ender_dust', '#c:ender_pearls', null, null, 'ae2:inscriber/ender_dust');
 });

--- a/kubejs/startup_scripts/Custom/InfinityCells.js
+++ b/kubejs/startup_scripts/Custom/InfinityCells.js
@@ -30,8 +30,8 @@ global.infCells = [
 
 StartupEvents.registry('item', e => {
   /**
-   * @param {String} id
-   * @param {String} type
+   * @param {string} id
+   * @param {string} type
    */
   let createInfCell = (id, type) => {
     let strippedId = id.includes(':') ? id.split(':')[1] : id;


### PR DESCRIPTION
Used `$ItemStack_` where quantities can be defined, instead of `Special.Item`(primarely for clarity). Used `Special.*` when possible, as it is a global namespace.

Minor refactors to enable adding JSDoc.

Replaced invalid `for (let [k, v] in obj)` loops with `for (let [k, v] of Object.entries(obj))`. This works in KubeJS but isn't valid JavaScript syntax.