### PR TITLE
exclude hopper upgrades when unifying storage upgrades

### DIFF
--- a/kubejs/server_scripts/unify/storage_upgrades.js
+++ b/kubejs/server_scripts/unify/storage_upgrades.js
@@ -8,13 +8,19 @@
     'sophisticatedbackpacks:battery_upgrade',
     'sophisticatedbackpacks:everlasting_upgrade',
     'sophisticatedbackpacks:inception_upgrade',
-    'sophisticatedbackpacks:tool_swapper_upgrade',
+    'sophisticatedbackpacks:tool_swapper_upgrade'
+  ];
+
+  // Exclude upgrades that are unique to Sophisticated Storage
+  let storageUnique = [
+    'sophisticatedstorage:hopper_upgrade',
+    'sophisticatedstorage:advanced_hopper_upgrade'
   ];
 
   ServerEvents.tags('item', e => {
     // Hide and remove old upgrades from Sophisticated Storage
     Ingredient.of('#sophisticatedstorage:upgrade').itemIds.forEach(id => {
-      if (!id.includes('sophisticatedbackpacks:')) {
+      if (!id.includes('sophisticatedbackpacks:') && !storageUnique.includes(id)) {
         disableItem(id, 'Sophisticated Backpacks Upgrades');
       }
     });


### PR DESCRIPTION
add a storageUnique as a blacklist filter and exclude hopper upgrades. This fix addresses issue #513 