### PR TITLE
fix: prevent vanilla hopper placement near mob mashers

### DIFF
--- a/kubejs/server_scripts/Mods/MobGrindingUtils/HopperFix.js
+++ b/kubejs/server_scripts/Mods/MobGrindingUtils/HopperFix.js
@@ -1,0 +1,19 @@
+const MOB_MASHER = 'mob_grinding_utils:saw';
+const HOPPER = 'minecraft:hopper';
+const commonSides = ['north', 'south', 'east', 'west'];
+
+function preventPlacement(type, extraDir, condition) {
+  const directions = extraDir ? commonSides.concat(extraDir) : commonSides;
+  BlockEvents.placed(type, event => {
+    const { block, player } = event;
+    if (directions.some(dir => condition(block[dir].id))) {
+      player.tell(`You can't place that here.`);
+      event.cancel();
+    }
+  });
+}
+
+// Hoppers can't be placed next to a mob masher (excluding below)
+preventPlacement(HOPPER, 'down', id => id === MOB_MASHER);
+// Mob mashers can't be placed next to a hopper (excluding above)
+preventPlacement(MOB_MASHER, 'up', id => id === HOPPER);


### PR DESCRIPTION
This pull request prevents using hoppers to upgrade mob mashers, bypassing limits.

Temporary workaround for https://github.com/vadis365/Mob-Grinding-Utils/issues/328, pending a fix from the MGU author (no commits since Dec 2024)