### PR TITLE
fix: resolve undefined invader path for custom bosses

### DIFF
--- a/kubejs/server_scripts/Mods/Apothic/Gateways.js
+++ b/kubejs/server_scripts/Mods/Apothic/Gateways.js
@@ -162,7 +162,7 @@ ServerEvents.generateData('after_mods', e => {
       entities: [
         {
           type: 'apotheosis:invader',
-          invader: `craftoria:custom_bosses/${boss.id}`,
+          invader: `craftoria:custom_bosses/${boss}`,
         },
       ],
       rewards: [


### PR DESCRIPTION
This pull request fixes an error where `boss` was treated as an object (boss.id) instead of a string. Resulting in custom bosses not being loaded.