### PR TITLE
Add missing keybinding and generic error handling to keybindjs script

### DIFF
--- a/kubejs/client_scripts/Keybinds.js
+++ b/kubejs/client_scripts/Keybinds.js
@@ -133,16 +133,29 @@ KeyBindJSEvents.modify(event => {
     /** @type {Array<string>} */
     let keyParts = k.split('.');
     let mod = v.mod ?? keyParts.find(part => global.modList.contains(part));
+
+    // Skip if the mod is not loaded, to avoid errors.
     if (!Platform.isLoaded(mod)) {
-      // Skip if the mod is not loaded, to avoid errors.
-      console.warn(`Skipping: ${k} -> ${v} (${mod} not loaded)`);
+      console.warn(`Skipping: ${k} -> ${JSON.stringify(v)} (${mod} not loaded)`);
       continue;
     }
 
-    if (!v.remove) {
-      if (v.key) event.modifyKey(k, v.key);
-      if (v.modifier) event.modifyModifier(k, v.modifier);
-      if (v.category) event.modifyCategory(k, v.category);
-    } else event.remove(k);
+    // Skip if the keybind doesn't exist but the mod is present
+    if (KeyBindUtil.findKeyMappingInAllKeyMapping(k) == null) {
+      console.warn(`Skipping: ${k} -> ${JSON.stringify(v)} (Keybinding not found)`);
+      continue;
+    }
+
+    try {
+      if (!v.remove) {
+        if (v.key) event.modifyKey(k, v.key);
+        if (v.modifier) event.modifyModifier(k, v.modifier);
+        if (v.category) event.modifyCategory(k, v.category);
+      } else event.remove(k);
+    } catch({message}) {
+      // unknown error case. 
+      // This keybinding script isnt critical so we dont want to stop client loading
+      console.warn(`Unable to fully modify Keybind ${k} due to error: ${message}`);
+    }
   }
 });


### PR DESCRIPTION
Removing some mods (like toomanyrecipeviewers) creates a situation where the jade keybindings no longer exist. 

This pull request adds handling to look up the keybinding and if it doesnt exist, it skips that key modification. This should handle cases where keybindings are added to namespaces that dont match their mod id.

This also wraps the modification in a try-catch in case modification fails so that failed keybinding modification doesnt prevent client load.