### PR TITLE
Fix Ars Elemental tree map color, FTB Chunks

### DIFF
--- a/kubejs/assets/ars_elemental/ftbchunks_block_colors.json
+++ b/kubejs/assets/ars_elemental/ftbchunks_block_colors.json
@@ -1,0 +1,3 @@
+{
+	"yellow_archwood_leaves": "#F5CA2F"
+}


### PR DESCRIPTION
Fixed ars elemental flashing archwood trees not displaying yellow on map due to bug in ftb chunks.