### PR TITLE
Improve changelog display and script portability

### DIFF
--- a/automation/scripts/README.md
+++ b/automation/scripts/README.md
@@ -34,12 +34,20 @@ Only `feat` and `fix` commits appear in the changelog. To exclude a commit, use 
 
 **Good:** `feat(quests): add mycelial reactor quest` - imperative verb shows action taken
 
-**Important:** Bump pack version in [`pack.toml`](../../pack.toml) first, or the script will warn you.
+**Important:** Bump pack version in [`pack.toml`](../../../pack.toml) first, or the script will warn you.
 
 Run inside a git repository so it can detect your uncommitted `pack.toml` changes:
 
+You can run this inside `automation/scripts` (your current working directory):
+
 ```bash
-bun run scripts/generate-changelog.js
+bun generate-changelog
+```
+
+Or from anywhere:
+
+```bash
+bun path/to/generate-changelog.js
 ```
 
 The script auto-detects the last version bump, analyzes changes, processes mod updates, and generates formatted output. No editing is required.

--- a/automation/scripts/package.json
+++ b/automation/scripts/package.json
@@ -1,3 +1,6 @@
 {
-  "type": "module"
+  "type": "module",
+  "scripts": {
+    "generate-changelog": "bun src/generate-changelog.js"
+  }
 }

--- a/automation/scripts/src/generate-changelog.js
+++ b/automation/scripts/src/generate-changelog.js
@@ -158,7 +158,7 @@ function generateChangelogContent(features, fixes, addedMods, removedMods) {
     `${links}\n---`,
   ].filter(Boolean);
 
-  if (sections.length < 4) sections.splice(-1, 0, "\n\n* Nothing changed");
+  if (sections.length === 2) sections.splice(-1, 0, "\n\n* Nothing changed");
 
   return sections.join("");
 }
@@ -172,6 +172,8 @@ function generateModChangelog(addedMods, removedMods, changedMods, oldPackMetada
     removedMods.length && `### Removed\n${removedMods.join("\n")}`,
     changedMods.length && `### Updated\n${changedMods.join("\n")}`,
   ].filter(Boolean);
+
+  if (sections.length === 1) sections.push("* Nothing changed");
 
   return sections.join("\n\n");
 }

--- a/automation/scripts/src/generate-changelog.js
+++ b/automation/scripts/src/generate-changelog.js
@@ -7,10 +7,10 @@ import {
   writeTextToFile,
 } from "./utils";
 import { $, Glob } from "bun";
-import packMetadata from "../../pack.toml";
+import packMetadata from "../../../pack.toml";
 
 const CONFIG = {
-  gitRepoPath: path.resolve(import.meta.dir, "..", ".."),
+  gitRepoPath: path.resolve(import.meta.dir, "..", "..", ".."),
   packVersion: null,
   oldPackVersion: null,
   fileId: "123456", // Do not change this
@@ -182,9 +182,9 @@ async function generateChangelog() {
     throw new Error("Git is required but was not found on the system.");
   }
 
-  await initializeConfig();
-
   $.cwd(CONFIG.gitRepoPath);
+
+  await initializeConfig();
 
   const [oldPackMetadata, oldMods] = await getCommitMetadataFiles(
     CONFIG.cutoffCommitHash
@@ -259,6 +259,6 @@ async function generateChangelog() {
 }
 
 generateChangelog().catch(error => {
-  console.error("An error occurred during changelog generation:", error);
+  console.error("An error occurred during changelog generation:\n", error);
   process.exit(1);
 });

--- a/automation/scripts/src/utils.js
+++ b/automation/scripts/src/utils.js
@@ -36,7 +36,7 @@ export async function getLatestBumpCommitHash(branchName = "HEAD") {
   const tagVersion = tagRefs.replace(/^tag: v?/, "").trim();
   const versionBumpRegex = /version bump (\d+\.\d+(?:\.\d+)?)$/;
 
-  for await (const line of $`git log ${branchName} --oneline --pretty=format:"%h|%s"`.lines()) {
+  for await (const line of $`git log ${branchName} --oneline --pretty="%h|%s"`.lines()) {
     const [bumpCommitHash, message] = line.split("|");
     const match = versionBumpRegex.exec(message);
     if (!match) continue;


### PR DESCRIPTION
- Fix "Nothing Changed" display in both main and mod changelogs (corrected typo + addition)
- Allow script to be run from any directory by setting cwd before config initialization(corrected typo*)

Both of these were intended to be already in, but I realized I made some silly mistakes in line positions and a few other things😔