### PR TITLE
Balance Just Dire Things fluid fuel values

### DIFF
--- a/kubejs/server_scripts/Mods/ModernIndustrialization/DataMaps.js
+++ b/kubejs/server_scripts/Mods/ModernIndustrialization/DataMaps.js
@@ -37,13 +37,13 @@ ServerEvents.generateData('after_mods', e => {
   e.json('modern_industrialization:data_maps/fluid/fluid_fuels', {
     values: {
       'justdirethings:refined_t4_fluid_source': {
-        eu_per_mb: 800
+        eu_per_mb: 2592
       },
       'justdirethings:refined_t3_fluid_source': {
-        eu_per_mb: 400
+        eu_per_mb: 864
       },
       'justdirethings:refined_t2_fluid_source': {
-        eu_per_mb: 200
+        eu_per_mb: 288
       },
     }
   });


### PR DESCRIPTION
This adjusts the fuel values, in EU/mB, of the three fluid fuels from Just Dire Things to fully take into account the fuel value of the JDT coal corresponding to each fluid tier. This makes it practical to produce JDT fluid fuels even after the reduction in JDT coal enrichment yields in the Ooze Lab from 1:1 to 9:4.

See comments on https://github.com/TeamAOF/Craftoria/commit/bf00911ec7e768320b41bebf1ff677cc2f6229a8 and https://github.com/TeamAOF/Craftoria/commit/bbeff6e3fbca390c00a27dab3c4a8d79e15a3a3a for justification and work showing JDT fuel production still produces a good return on investment while not being overpowered.