### PR TITLE
Make PneumaticCraft fluid fuels directly usable as MI fuels

### DIFF
--- a/kubejs/server_scripts/Mods/ModernIndustrialization/DataMaps.js
+++ b/kubejs/server_scripts/Mods/ModernIndustrialization/DataMaps.js
@@ -45,6 +45,27 @@ ServerEvents.generateData('after_mods', e => {
       'justdirethings:refined_t2_fluid_source': {
         eu_per_mb: 200
       },
+      'pneumaticcraft:lpg': {
+        eu_per_mb: 720
+      },
+      'pneumaticcraft:gasoline': {
+        eu_per_mb: 600
+      },
+      'pneumaticcraft:kerosene': {
+        eu_per_mb: 440
+      },
+      'pneumaticcraft:diesel': {
+        eu_per_mb: 400
+      },
+      'pneumaticcraft:biodiesel': {
+        eu_per_mb: 250
+      },
+      'pneumaticcraft:ethanol': {
+        eu_per_mb: 160
+      },
+      'pneumaticcraft:oil': {
+        eu_per_mb: 16
+      },
     }
   });
 });


### PR DESCRIPTION
PneumaticCraft fluid fuels can be burned directly in MI's boilers and diesel generators.
The fuel values are based off the corresponding fuels from MI where said fuel exists there, and are otherwise proportional to the burn time of a bucket of the fuel in a furnace.

Fixes https://github.com/TeamAOF/Craftoria/issues/630.