### PR TITLE
Unify the Quantum Storage and Digital Singularity Components

### DIFF
--- a/kubejs/data/bigger_ae2/recipe/cell_upgrade/quantum_chemical_storage_cell.json
+++ b/kubejs/data/bigger_ae2/recipe/cell_upgrade/quantum_chemical_storage_cell.json
@@ -1,0 +1,20 @@
+{
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "appmek"
+    }
+  ],
+  "type": "ae2:storage_cell_disassembly",
+  "cell": "bigger_ae2:quantum_chemical_storage_cell",
+  "cell_disassembly_items": [
+    {
+      "count": 1,
+      "id": "bigger_ae2:advanced_chemical_cell_housing"
+    },
+    {
+      "count": 1,
+      "id": "advanced_ae:quantum_storage_component"
+    }
+  ]
+}

--- a/kubejs/data/bigger_ae2/recipe/cell_upgrade/quantum_fluid_storage_cell.json
+++ b/kubejs/data/bigger_ae2/recipe/cell_upgrade/quantum_fluid_storage_cell.json
@@ -1,0 +1,14 @@
+{
+  "type": "ae2:storage_cell_disassembly",
+  "cell": "bigger_ae2:quantum_fluid_storage_cell",
+  "cell_disassembly_items": [
+    {
+      "count": 1,
+      "id": "advanced_ae:quantum_storage_component"
+    },
+    {
+      "count": 1,
+      "id": "bigger_ae2:advanced_fluid_cell_housing"
+    }
+  ]
+}

--- a/kubejs/data/bigger_ae2/recipe/cell_upgrade/quantum_flux_storage_cell.json
+++ b/kubejs/data/bigger_ae2/recipe/cell_upgrade/quantum_flux_storage_cell.json
@@ -1,0 +1,20 @@
+{
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "appex"
+    }
+  ],
+  "type": "ae2:storage_cell_disassembly",
+  "cell": "bigger_ae2:quantum_flux_storage_cell",
+  "cell_disassembly_items": [
+    {
+      "count": 1,
+      "id": "bigger_ae2:advanced_flux_cell_housing"
+    },
+    {
+      "count": 1,
+      "id": "advanced_ae:quantum_storage_component"
+    }
+  ]
+}

--- a/kubejs/data/bigger_ae2/recipe/cell_upgrade/quantum_item_storage_cell.json
+++ b/kubejs/data/bigger_ae2/recipe/cell_upgrade/quantum_item_storage_cell.json
@@ -1,0 +1,14 @@
+{
+  "type": "ae2:storage_cell_disassembly",
+  "cell": "bigger_ae2:quantum_item_storage_cell",
+  "cell_disassembly_items": [
+    {
+      "count": 1,
+      "id": "advanced_ae:quantum_storage_component"
+    },
+    {
+      "count": 1,
+      "id": "bigger_ae2:advanced_item_cell_housing"
+    }
+  ]
+}

--- a/kubejs/data/bigger_ae2/recipe/cell_upgrade/quantum_source_storage_cell.json
+++ b/kubejs/data/bigger_ae2/recipe/cell_upgrade/quantum_source_storage_cell.json
@@ -1,0 +1,20 @@
+{
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "arseng"
+    }
+  ],
+  "type": "ae2:storage_cell_disassembly",
+  "cell": "bigger_ae2:quantum_source_storage_cell",
+  "cell_disassembly_items": [
+    {
+      "count": 1,
+      "id": "bigger_ae2:advanced_source_cell_housing"
+    },
+    {
+      "count": 1,
+      "id": "advanced_ae:quantum_storage_component"
+    }
+  ]
+}

--- a/kubejs/server_scripts/EMIThings/Hide.js
+++ b/kubejs/server_scripts/EMIThings/Hide.js
@@ -31,6 +31,8 @@ RecipeViewerEvents.removeEntriesCompletely('item', event => {
     event.remove(item.id);
   });
 
+  event.remove(['megacells:bulk_cell_component', 'bigger_ae2:quantum_cell_component']);
+
   event.remove(Ingredient.of('@displaydelight').except(['displaydelight:food_plate', 'displaydelight:small_food_plate']));
 });
 

--- a/kubejs/server_scripts/Mods/AE2/Recipes.js
+++ b/kubejs/server_scripts/Mods/AE2/Recipes.js
@@ -38,10 +38,31 @@ ServerEvents.recipes(event => {
     })
     .id('bigger_ae2:advanced_source_cell_housing');
 
+  event
+    .shaped('bigger_ae2:digital_singularity_cell_component', ['ASA', 'QGQ', 'AQA'], {
+      A: 'megacells:accumulation_processor',
+      S: 'ae2:spatial_cell_component_128',
+      Q: 'advanced_ae:quantum_storage_component',
+      G: 'ae2:quartz_vibrant_glass',
+    })
+    .id('bigger_ae2:digital_singularity_cell_component');
+
   event.replaceInput({ id: 'advanced_ae:quantum_helmet' }, 'minecraft:netherite_helmet', 'mekanism:mekasuit_helmet');
   event.replaceInput({ id: 'advanced_ae:quantum_chest' }, 'minecraft:netherite_chestplate', 'mekanism:mekasuit_bodyarmor');
   event.replaceInput({ id: 'advanced_ae:quantum_leggings' }, 'minecraft:netherite_leggings', 'mekanism:mekasuit_pants');
   event.replaceInput({ id: 'advanced_ae:quantum_boots' }, 'minecraft:netherite_boots', 'mekanism:mekasuit_boots');
+
+  event.replaceInput({ id: 'megacells:cells/standard/bulk_item_cell' }, 'megacells:bulk_cell_component', 'bigger_ae2:digital_singularity_cell_component');
+
+  event.replaceInput({ id: 'bigger_ae2:quantum_fluid_storage_cell' }, 'bigger_ae2:quantum_cell_component', 'advanced_ae:quantum_storage_component');
+  event.replaceInput({ id: 'bigger_ae2:quantum_chemical_storage_cell' }, 'bigger_ae2:quantum_cell_component', 'advanced_ae:quantum_storage_component');
+  event.replaceInput({ id: 'bigger_ae2:quantum_source_storage_cell' }, 'bigger_ae2:quantum_cell_component', 'advanced_ae:quantum_storage_component');
+
+  event.remove({ id: 'bigger_ae2:quantum_cell_component' });
+  event.shapeless('advanced_ae:quantum_storage_component', 'bigger_ae2:quantum_cell_component');
+
+  event.remove({ id: 'megacells:crafting/bulk_cell_component' });
+  event.shapeless('bigger_ae2:digital_singularity_cell_component', 'megacells:bulk_cell_component');
 
   ae2.crystalAssembler('advanced_ae:adv_pattern_provider_capacity_upgrade', [
     '#ae2:metal_ingots',

--- a/kubejs/server_scripts/Mods/AE2/Tooltips.js
+++ b/kubejs/server_scripts/Mods/AE2/Tooltips.js
@@ -6,4 +6,14 @@ ItemEvents.modifyTooltips(e => {
     Text.translate('tooltip.ae2wtlib.quantum_bridge_card.2').gray(),
     Text.translate('tooltip.ae2wtlib.quantum_bridge_card.3').gray(),
   ]);
+
+  e.add('bigger_ae2:quantum_cell_component', [
+    Text.red('This item has been disabled in favor of Advanced AE\'s Quantum Storage Component.'),
+    Text.red('Please convert this item in any crafting table, as it is no longer craftable or usable.'),
+  ]);
+
+  e.add('megacells:bulk_cell_component', [
+    Text.red('This item has been disabled in favor of Bigger AE2\'s Digital Singularity Cell Component.'),
+    Text.red('Please convert this item in any crafting table, as it is no longer craftable or usable.'),
+  ]);
 });


### PR DESCRIPTION
Bigger AE2's Quantum Cells use Advanced AE's Quantum Storage Components instead of Bigger AE2's Quantum Cell Components; this affects both their crafting recipe and disassembly outputs.

The MEGA Bulk Item Storage Cell uses a Digital Singularity Cell Component from Bigger AE2 in place of MEGA Cells' own Bulk Storage Component.

The Digital Singularity Cell Component gets a new recipe (subject to change), which costs Accumulation Processors, a Vibrant Quartz Glass, and a Spatial Storage Component in addition to Quantum Storage Components. This more closely matches the recipe difficulty of said Quantum Storage Components. Preview of the new recipe:
<img width="252" height="124" alt="Digital Singularity Cell Component recipe" src="https://github.com/user-attachments/assets/0f218361-6951-41b0-97e1-909e0910a643" />

These changes get rid of any uses for Bigger AE2's Quantum Cell Components and MEGA Cells' Bulk Storage Components, unifying them with Advanced AE's Quantum Storage Components and Bigger AE2's Digital Singularity Cell Components respectively. As a side effect, getting truly infinite item and fluid storage (rather than a large but finite amount with overflow voiding) will require some progression into Advanced AE, the same progression that is also required to craft the necessary components for a Quantum Computer.