### PR TITLE
fix cursed spellbook reference in iron's apothic invaders datapack mod

### DIFF
--- a/kubejs/data/apotheosis/gear_sets/cultist.json
+++ b/kubejs/data/apotheosis/gear_sets/cultist.json
@@ -1,0 +1,59 @@
+{
+    "type": "placebo:gear_set",
+    "boots": [
+        {
+            "stack": {
+                "count": 1,
+                "id": "irons_spellbooks:cultist_boots"
+            },
+            "weight": 10
+        }
+    ],
+    "chestplates": [
+        {
+            "stack": {
+                "count": 1,
+                "id": "irons_spellbooks:cultist_chestplate"
+            },
+            "weight": 10
+        }
+    ],
+    "helmets": [
+        {
+            "stack": {
+                "count": 1,
+                "id": "irons_spellbooks:cultist_helmet"
+            },
+            "weight": 10
+        }
+    ],
+    "leggings": [
+        {
+            "stack": {
+                "count": 1,
+                "id": "irons_spellbooks:cultist_leggings"
+            },
+            "weight": 10
+        }
+    ],
+    "mainhands": [
+        {
+            "stack": {
+                "count": 1,
+                "id": "irons_spellbooks:graybeard_staff"
+            },
+            "weight": 10
+        },
+        {
+            "stack": {
+                "count": 1,
+                "id": "irons_spellbooks:cursed_doll_spell_book"
+            },
+            "weight": 2
+        }
+    ],
+    "tags": [
+        "cultist"
+    ],
+    "weight": 100
+}

--- a/kubejs/data/apotheosis/gear_sets/various/cultist.json
+++ b/kubejs/data/apotheosis/gear_sets/various/cultist.json
@@ -1,0 +1,59 @@
+{
+    "type": "placebo:gear_set",
+    "boots": [
+        {
+            "stack": {
+                "count": 1,
+                "id": "irons_spellbooks:cultist_boots"
+            },
+            "weight": 10
+        }
+    ],
+    "chestplates": [
+        {
+            "stack": {
+                "count": 1,
+                "id": "irons_spellbooks:cultist_chestplate"
+            },
+            "weight": 10
+        }
+    ],
+    "helmets": [
+        {
+            "stack": {
+                "count": 1,
+                "id": "irons_spellbooks:cultist_helmet"
+            },
+            "weight": 10
+        }
+    ],
+    "leggings": [
+        {
+            "stack": {
+                "count": 1,
+                "id": "irons_spellbooks:cultist_leggings"
+            },
+            "weight": 10
+        }
+    ],
+    "mainhands": [
+        {
+            "stack": {
+                "count": 1,
+                "id": "irons_spellbooks:graybeard_staff"
+            },
+            "weight": 10
+        },
+        {
+            "stack": {
+                "count": 1,
+                "id": "irons_spellbooks:cursed_doll_spell_book"
+            },
+            "weight": 2
+        }
+    ],
+    "tags": [
+        "cultist"
+    ],
+    "weight": 100
+}


### PR DESCRIPTION
fixes:
```
[06:45:44] [main/ERROR] [placebo/]: Failed parsing gear_sets file apotheosis:cultist.
[06:45:44] [main/ERROR] [placebo/]: Underlying Exception: 
io.netty.handler.codec.CodecException: Codec failure for type gear_sets, message: Failed to read non-optional item id irons_spellbooks:cursed_doll_spellbook
```

`irons_spellbooks:cursed_doll_spellbook` should be `irons_spellbooks:cursed_doll_spell_book`