### PR TITLE
refactor: replace colors array with `Color.DYE`

### DIFF
--- a/kubejs/server_scripts/Mods/AE2/Recipes.js
+++ b/kubejs/server_scripts/Mods/AE2/Recipes.js
@@ -77,18 +77,13 @@ ServerEvents.recipes(event => {
     event.replaceInput({ id: id }, 'minecraft:iron_ingot', '#ae2:metal_ingots');
   });
 
-  
   // added reversable recipes for dyed ae2 cables, covered and not. - inno
-  const colors = [
-    'white', 'light_gray', 'gray', 'black', 'lime', 'yellow', 'orange', 'brown', 'red', 'pink', 'magenta', 'purple', 'blue', 'light_blue', 'cyan', 'green'
-  ];
-
   const reversablePairs = [
-    { a: "smart_cable", b: "smart_dense_cable", sCount: 4, dCount: 1},
-    { a: "covered_cable", b: "covered_dense_cable", sCount: 4, dCount: 1}
+    { a: 'smart_cable', b: 'smart_dense_cable', sCount: 4, dCount: 1 },
+    { a: 'covered_cable', b: 'covered_dense_cable', sCount: 4, dCount: 1 }
   ];
 
-  colors.forEach(color => {
+  Color.DYE.forEach(color => {
     reversablePairs.forEach(pair => {
       event.shapeless(
         `${pair.sCount}x ae2:${color}_${pair.a}`,


### PR DESCRIPTION
This pull request simplifies dye color handling by using the `Color` namespace.