### PR TITLE
fix: (work-around) disable post-process-shaders in Spectrum

### DIFF
--- a/config/spectrum-startup.toml
+++ b/config/spectrum-startup.toml
@@ -9,7 +9,7 @@ wind_sim = false
 wind_sim_interval = 3
 reduced_wind_particles = false
 #Post process shaders
-post_process_shaders = true
+post_process_shaders = false
 #Light Blocks emit particles without holding a Radiance Staff
 always_spawn_light_block_particles = false
 #Items transported by a Pastel Network spawn particles


### PR DESCRIPTION
Avoids a hard crash on some machines upon entering the DD.

See: https://github.com/DaFuqs/Spectrum/issues/887