### PR TITLE
Whitelist Spectrum multitool & workstaffs in knife unification (#810)

### DIFF
--- a/kubejs/server_scripts/unify/Knife.js
+++ b/kubejs/server_scripts/unify/Knife.js
@@ -3,7 +3,14 @@
   /** @type {Special.Mod[]} */
   let modWhitelist = ['farmersdelight', 'moredelight', 'arsdelight', 'twilightdelight', 'ends_delight'];
   /** @type {Special.Item[]} */
-  let itemWhitelist = ['aquaculture:neptunium_fillet_knife'];
+  let itemWhitelist = [
+    'aquaculture:neptunium_fillet_knife',
+    // Multitools/workstaffs that carry #c:tools/knife but function as paxels, not plain knives;
+    // keep their recipes and EMI visibility instead of unifying them away (#810).
+    'spectrum:multitool',
+    'spectrum:glass_crest_workstaff',
+    'spectrum:malachite_workstaff',
+  ];
 
   ServerEvents.recipes(e => {
     Ingredient.of('#c:tools/knife').stacks.forEach(item => {


### PR DESCRIPTION
## Summary

`kubejs/server_scripts/unify/Knife.js` iterates over every item in `#c:tools/knife` and, unless the item is whitelisted, pushes it into `globalItemRemovals` (which strips its crafting recipe) and into `almostunified:hide` (which hides it from EMI). Spectrum's Multitool, Glass Crest Workstaff, and Malachite Workstaff all carry the knife tag, so the unifier disabled them even though they are paxel-type multitools rather than plain knives.

## Root cause

Spectrum declares the tag membership itself, and the knife tag nests the workstaffs tag:

- `data/c/tags/item/tools/knife.json` -> `["spectrum:multitool", "#spectrum:workstaffs"]`
- `data/spectrum/tags/item/workstaffs.json` -> `["spectrum:malachite_workstaff", "spectrum:glass_crest_workstaff"]`

KubeJS flattens the nested tag when resolving `Ingredient.of('#c:tools/knife').stacks`, so all three resolved item ids reach the removal path.

## Fix

Add the three resolved item ids to the existing `itemWhitelist` (the same escape hatch already used for `aquaculture:neptunium_fillet_knife`). `itemWhitelist.includes(item.id)` is checked in both the recipe-removal loop and the EMI-hide loop, so this single change restores both the recipes and the EMI visibility for all three items.

```js
let itemWhitelist = [
  'aquaculture:neptunium_fillet_knife',
  'spectrum:multitool',
  'spectrum:glass_crest_workstaff',
  'spectrum:malachite_workstaff',
];
```

## Scope and risk

Minimal. The whitelist is a skip-list, so the change touches only these three items; every other knife still unifies exactly as before. I used `itemWhitelist` rather than adding `spectrum` to `modWhitelist` so that any genuine plain knife Spectrum might add in a future version still gets unified.

Fixes #810

🤖 Generated with [Claude Code](https://claude.com/claude-code)
