### PR TITLE
permit bedrock anvil to apply overleveled enchants

### DIFF
--- a/config/spectrum-startup.toml
+++ b/config/spectrum-startup.toml
@@ -23,7 +23,7 @@ add_item_tooltips = true
 #The vanilla anvil caps enchantment levels at the max level for the enchantment
 #So enchanted books that exceed the enchantments natural max level get capped
 #If true the bedrock anvil will not cap the enchantments level to it's natural max level
-bedrock_anvil_can_exceed_max_vanilla_enchantment_level = false
+bedrock_anvil_can_exceed_max_vanilla_enchantment_level = true
 #The chance that an Enderman is holding a special treasure block on spawn
 #Separate value for Endermen spawning in the end, since there are LOTS of them there
 #Those blocks do not gate progression, so it is not that drastic not finding any right away.


### PR DESCRIPTION
Apothic enchanting makes overleveled enchantments attainable, but does not modify the vanilla enchantment cap value. 

Spectrum's bedrock anvil does not apply overleveled enchantments correctly unless this config value is set to `true`

Refs: https://github.com/DaFuqs/Spectrum/issues/955